### PR TITLE
Better support for php8.x L9 client

### DIFF
--- a/src/Middleware/OAuthExceptionHandlerMiddleware.php
+++ b/src/Middleware/OAuthExceptionHandlerMiddleware.php
@@ -46,7 +46,7 @@ class OAuthExceptionHandlerMiddleware
                 'error_description' => $e->getMessage(),
             ];
 
-            return new JsonResponse($data, $e->httpStatusCode, $e->getHttpHeaders());
+            return new JsonResponse($data, $e->httpStatusCode);
         }
     }
 }


### PR DESCRIPTION
## 🚨 Once accepted/merged, merge changes from 8.x into 9.x.

## Description
Returning error headers break guzzle client under php8.x. 

## Solution
No longer return headers for exceptions.


Exception response contain some header that is not parsable by guzzle client:
<img width="913" alt="image" src="https://github.com/ellipsesynergie/oauth2-server-laravel/assets/24227081/b894d344-1b90-42ed-94d3-403f70fb5ee4">

Success response dont contain this kind of information:
<img width="912" alt="image" src="https://github.com/ellipsesynergie/oauth2-server-laravel/assets/24227081/62c2ee71-fcac-4c21-a1f9-e821e47daa8e">
